### PR TITLE
feat: Change package type from 'library' to 'symfony-bundle'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "mati365/ckeditor5-symfony",
   "version": "1.0.9",
   "description": "CKEditor 5 integration for Symfony",
-  "type": "library",
+  "type": "symfony-bundle",
   "license": "MIT",
   "keywords": [
     "symfony",


### PR DESCRIPTION
Is this is a library or a symfony-bundle ?
This would lead to not to have todo `step 2 Enable the bundle` necessary if `symfony/flex `is used
